### PR TITLE
switch to python 3.11 for the next update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8
+FROM python:3.11
 LABEL maintainer="Andre Klaerner <kandre@ak-online.be>"
 ENV LC_ALL=C.UTF-8 LANG=C.UTF-8
 RUN useradd -m -s /bin/bash vds

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 vdirsyncer == 0.19.2
-python-aiohttp-oauthlib
+aiohttp-oauthlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 vdirsyncer == 0.19.2
-aiohttp-oauthlib
+vdirsyncer[google]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-vdirsyncer == 0.16.8
-requests-oauthlib
+vdirsyncer == 0.19.2
+python-aiohttp-oauthlib


### PR DESCRIPTION
python 3.11 is the newest officially supported python that vdirsyncer can use. Also since the next version is >0.19, we need python-aiohttp-oauthlib instead of requests-oauthlib